### PR TITLE
Basic index functionality

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,6 @@ Metrics/BlockLength:
   ExcludedMethods:
     - "configure"
     - "describe"
+
+Metrics/MethodLength:
+  Max: 13

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,4 @@ Metrics/BlockLength:
     - "gladius.gemspec"
   ExcludedMethods:
     - "configure"
+    - "describe"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,5 @@ Metrics/LineLength:
 Metrics/BlockLength:
   Exclude:
     - "gladius.gemspec"
+  ExcludedMethods:
+    - "configure"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
 # Gladius
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/gladius`. To experiment with that code, run `bin/console` for an interactive prompt.
+Gladius is a zero-setup tool for accessing JSONAPI Resources.
 
-TODO: Delete this and the text above, and describe your gem
+```ruby
+agent = Gladius::Agent.new("http://jsonapi-example.com/posts")
+post = agent.index[0]
+print post
+Posts: 0223c8ea-0c31-4901-b20e-99123b408e08
+  author_id: 80013143-e3fe-435e-8d86-b3da896625fa
+       name: Great Post
+  post_type: blog
+#<Gladius::Resource:0x007f83a98fefb0>=> nil
+
+post.name = "Even Better"
+updated_post = post.save!
+print updated_post
+Posts: 0223c8ea-0c31-4901-b20e-99123b408e08
+  author_id: 80013143-e3fe-435e-8d86-b3da896625fa
+       name: Even Better
+  post_type: blog
+#<Gladius::Resource:0x007f83a8bea6f8>=> nil
+```
 
 ## Installation
 
@@ -22,7 +40,22 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+First start up a `Gladius::Agent` with a root resource URI:
+
+```ruby
+agent = Gladius::Agent.new("https://jsonapi-example.org/users")
+```
+
+* `#index` returns `Resource`-wrapped resuls from `GET`.
+* `#get(id)` makes a `GET` call to the member(id) path of the base.
+* `#new(attributes)` creates a new `Resource`.
+
+When you have a `Resource`:
+
+* `#<attribute>`: Returns value of attribute
+* `#<attribute>=`: Sets the value
+* `#save!`: Create or Update the resource
+* `#to_s`: Pretty print the resource
 
 ## Development
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,4 @@
 machine:
-  # Version of ruby to use
   ruby:
     version:
       ruby-2.4.0

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,10 @@ checkout:
   post:
     - git fetch origin --depth=1000000
 
+dependencies:
+  pre:
+    - gem install bundler
+
 test:
   override:
     - bundle exec rspec -r rspec_junit_formatter --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec-junit.xml --format documentation $stdout:

--- a/gladius.gemspec
+++ b/gladius.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "~> 0.11.0"
+  spec.add_dependency "addressable", "~> 2.5.0"
   # spec.add_dependency "faraday_middleware", "~> 0.11.0"
 
   spec.add_development_dependency "bundler", "~> 1.14"

--- a/gladius.gemspec
+++ b/gladius.gemspec
@@ -33,11 +33,16 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "~> 0.11.0"
+  # spec.add_dependency "faraday_middleware", "~> 0.11.0"
 
   spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "database_cleaner", "~> 1.5.3"
+  spec.add_development_dependency "jsonapi-resources", "~> 0.9.0"
+  spec.add_development_dependency "railties", "~> 5.0.2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.5.0"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.2.3"
   spec.add_development_dependency "pronto", "~> 0.8.0"
   spec.add_development_dependency "pronto-rubocop", "~> 0.8.0"
+  spec.add_development_dependency "sqlite3", "~> 1.3.13"
 end

--- a/lib/gladius.rb
+++ b/lib/gladius.rb
@@ -7,3 +7,4 @@ end
 
 require_relative "gladius/version"
 require_relative "gladius/agent"
+require_relative "gladius/resource"

--- a/lib/gladius.rb
+++ b/lib/gladius.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
-require "gladius/version"
 
 # Main module for Gladius
 module Gladius
   # Your code goes here...
 end
+
+require_relative "gladius/version"
+require_relative "gladius/agent"

--- a/lib/gladius/agent.rb
+++ b/lib/gladius/agent.rb
@@ -21,32 +21,27 @@ module Gladius
       handle_response(response)
     end
 
-    def create!(attrs)
-      type = uri.path.split("/").pop
-      response = _conn.post(uri, { data: {
-        type: type,
-        attributes: attrs
-      } }.to_json)
+    def create(resource)
+      response = _conn.post(uri, resource.to_jsonapi_hash.to_json)
       check_response(response)
       handle_response(response)
     end
 
     def get(id)
       response = _conn.get(member_uri_template.expand(id: id))
-      unless response.headers["Content-Type"] == "application/vnd.api+json"
-        raise "Something Wrong"
-      end
       check_response(response)
       handle_response(response)
     end
 
-    def patch(resource)
+    def update(resource)
       response = _conn.patch(member_uri_template.expand(id: resource.id), resource.to_jsonapi_hash.to_json)
-      unless response.headers["Content-Type"] == "application/vnd.api+json"
-        raise "Something Wrong"
-      end
       check_response(response)
       handle_response(response)
+    end
+
+    def new(attributes)
+      Resource.new({ type: @uri.path.split("/").last, attributes: attributes },
+                   agent: self)
     end
 
     private
@@ -70,7 +65,7 @@ module Gladius
     end
 
     def handle_data(data)
-      Resource.new(data, self)
+      Resource.new(data, agent: self, new: false)
     end
 
     def member_uri_template

--- a/lib/gladius/agent.rb
+++ b/lib/gladius/agent.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 require "ostruct"
 require "faraday"
+require "addressable/uri"
+require "addressable/template"
 module Gladius
   # This is the basic client agent.
   class Agent
     attr_reader :_conn, :uri
 
     def initialize(uri, connection: Faraday.new)
-      @uri = uri
+      @uri = Addressable::URI.parse(uri)
       @_conn = apply_headers(connection)
     end
 
@@ -20,8 +22,9 @@ module Gladius
     end
 
     def create!(attrs)
+      type = uri.path.split("/").pop
       response = _conn.post(uri, { data: {
-        type: "posts",
+        type: type,
         attributes: attrs
       } }.to_json)
       unless response.headers["Content-Type"] == "application/vnd.api+json"
@@ -30,7 +33,23 @@ module Gladius
       JSON.parse(response.body, symbolize_names: true)
     end
 
+    def get(id)
+      response = _conn.get(member_uri_template.expand(id: id))
+      unless response.headers["Content-Type"] == "application/vnd.api+json"
+        raise "Something Wrong"
+      end
+      Resource.build(JSON.parse(response.body, symbolize_names: true), self)
+    end
+
+    def patch(resource)
+      _conn.patch(member_uri_template.expand(id: resource.id), resource.to_jsonapi_hash.to_json)
+    end
+
     private
+
+    def member_uri_template
+      Addressable::Template.new(uri.dup.to_s + "/{id}")
+    end
 
     def apply_headers(conn)
       conn.headers["Content-Type"] = "application/vnd.api+json"

--- a/lib/gladius/agent.rb
+++ b/lib/gladius/agent.rb
@@ -34,7 +34,8 @@ module Gladius
     end
 
     def update(resource)
-      response = _conn.patch(member_uri_template.expand(id: resource.id), resource.to_jsonapi_hash.to_json)
+      update_uri = member_uri_template.expand(id: resource.id)
+      response = _conn.patch(update_uri, resource.to_jsonapi_hash.to_json)
       check_response(response)
       handle_response(response)
     end

--- a/lib/gladius/agent.rb
+++ b/lib/gladius/agent.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require "ostruct"
+require "faraday"
+module Gladius
+  # This is the basic client agent.
+  class Agent
+    attr_reader :_conn, :uri
+
+    def initialize(uri, connection: Faraday.new)
+      @uri = uri
+      @_conn = apply_headers(connection)
+    end
+
+    def index
+      response = _conn.get(uri)
+      unless response.headers["Content-Type"] == "application/vnd.api+json"
+        raise "Something Wrong"
+      end
+      JSON.parse(response.body, symbolize_names: true)
+    end
+
+    def create!(attrs)
+      response = _conn.post(uri, { data: {
+        type: "posts",
+        attributes: attrs
+      } }.to_json)
+      unless response.headers["Content-Type"] == "application/vnd.api+json"
+        raise "Something Wrong"
+      end
+      JSON.parse(response.body, symbolize_names: true)
+    end
+
+    private
+
+    def apply_headers(conn)
+      conn.headers["Content-Type"] = "application/vnd.api+json"
+      conn.headers["Accept"] = "application/vnd.api+json"
+      conn
+    end
+  end
+end

--- a/lib/gladius/resource.rb
+++ b/lib/gladius/resource.rb
@@ -1,0 +1,27 @@
+require "ostruct"
+
+module Gladius
+  # A class which enables us to pleasantly interact with jsonapi documents.
+  class Resource < OpenStruct
+    attr_accessor :_agent
+    def self.build(data, agent)
+      type, id, attrs = data[:data].values_at(:type, :id, :attributes)
+      resource = new(attrs.merge(id: id, type: type))
+      resource._agent = agent
+      resource
+    end
+
+    def to_jsonapi_hash
+      attributes = @table.dup
+      { data: {
+        id: attributes.delete(:id),
+        type: attributes.delete(:type),
+        attributes: attributes
+      } }
+    end
+
+    def save!
+      _agent.patch(self)
+    end
+  end
+end

--- a/lib/gladius/resource.rb
+++ b/lib/gladius/resource.rb
@@ -5,7 +5,7 @@ module Gladius
   class Resource < OpenStruct
     attr_accessor :_agent
     def self.build(data, agent)
-      type, id, attrs = data[:data].values_at(:type, :id, :attributes)
+      type, id, attrs = data.values_at(:type, :id, :attributes)
       resource = new(attrs.merge(id: id, type: type))
       resource._agent = agent
       resource

--- a/lib/gladius/resource.rb
+++ b/lib/gladius/resource.rb
@@ -3,34 +3,49 @@ require "ostruct"
 module Gladius
   # A class which enables us to pleasantly interact with jsonapi documents.
   class Resource
-    attr_accessor :_agent, :data, :type, :id
+    attr_accessor :_agent, :_new, :data, :type, :id
 
-    def initialize(data, agent)
+    def initialize(data = {}, agent:, new: true)
       @type, @id, attrs = *data.values_at(:type, :id, :attributes)
-      @_agent = agent
       @data = OpenStruct.new(attrs)
+      @_agent = agent
+      @_new = new
     end
 
     def to_jsonapi_hash
       attributes = @data.dup
       { data: {
-        id: id,
+        id: (_new ? nil : id),
         type: type,
         attributes: attributes.to_h
-      } }
+      }.compact }
     end
 
     def save!
-      _agent.patch(self)
+      if _new
+        _agent.create(self)
+      else
+        _agent.update(self)
+      end
     end
 
     def respond_to_missing?(meth, *_args, &_block)
-      @data.respond_to?(meth)
+      @data.respond_to?(meth) || /=$/.match?(meth)
     end
 
     def method_missing(meth, *args, &block)
-      super unless @data.respond_to?(meth)
+      super unless respond_to_missing?(meth, *args, &block)
       @data.send(meth, *args, &block)
+    end
+
+    def to_s
+      attributes = data.dup.to_h.to_a
+      length = attributes.map(&:first).max_by(&:length).length
+      print "#{type[0].upcase}#{type[1..-1]}: #{id}\n"
+      attributes.map{|d| [length] + d}.each do |attr|
+        print format("%*s: %s", *attr) + "\n"
+      end
+      nil
     end
   end
 end

--- a/lib/gladius/resource.rb
+++ b/lib/gladius/resource.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "ostruct"
 
 module Gladius
@@ -38,11 +39,11 @@ module Gladius
       @data.send(meth, *args, &block)
     end
 
-    def to_s
+    def to_s # rubocop:disable Metrics/AbcSize
       attributes = data.dup.to_h.to_a
       length = attributes.map(&:first).max_by(&:length).length
       print "#{type[0].upcase}#{type[1..-1]}: #{id}\n"
-      attributes.map{|d| [length] + d}.each do |attr|
+      attributes.map { |d| [length] + d }.each do |attr|
         print format("%*s: %s", *attr) + "\n"
       end
       nil

--- a/spec/gladius/agent_spec.rb
+++ b/spec/gladius/agent_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 RSpec.describe(Gladius::Agent) do

--- a/spec/gladius/agent_spec.rb
+++ b/spec/gladius/agent_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe(Gladius::Agent) do
   describe "#parse_uri" do
     it "Splits the URI into base and resource_name on initialization" do
       agent = Gladius::Agent.new("http://test.com/foobars")
-      expect(agent.base_uri.to_s).to eq("http://test.com")
-      expect(agent.endpoint).to eq("foobars")
+      expect(agent.uri.to_s).to eq("http://test.com/foobars")
     end
   end
 end

--- a/spec/gladius/agent_spec.rb
+++ b/spec/gladius/agent_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe(Gladius::Agent) do
+  describe "#parse_uri" do
+    it "Splits the URI into base and resource_name on initialization" do
+      agent = Gladius::Agent.new("http://test.com/foobars")
+      expect(agent.base_uri.to_s).to eq("http://test.com")
+      expect(agent.endpoint).to eq("foobars")
+    end
+  end
+end

--- a/spec/gladius/resource_spec.rb
+++ b/spec/gladius/resource_spec.rb
@@ -4,13 +4,11 @@ module Gladius
   RSpec.describe(Resource) do
     let(:data_document) do
       {
-        data: {
-          type: "potatoes",
-          id: 12,
-          attributes: {
-            spots: 4,
-            name: "Spudley"
-          }
+        type: "potatoes",
+        id: 12,
+        attributes: {
+          spots: 4,
+          name: "Spudley"
         }
       }
     end
@@ -18,22 +16,22 @@ module Gladius
 
     describe "Basics" do
       it "supports initialization with a data document" do
-        resource = Resource.build(data_document, mock_agent)
+        resource = Resource.new(data_document, mock_agent)
         expect(resource.type).to eq("potatoes")
         expect(resource.spots).to eq(4)
         expect(resource.name).to eq("Spudley")
       end
 
       it "can be converted back into a data document" do
-        resource = Resource.build(data_document, mock_agent)
+        resource = Resource.new(data_document, mock_agent)
         jsonified = resource.to_jsonapi_hash
-        expect(jsonified).to eq(data_document)
+        expect(jsonified[:data]).to eq(data_document)
       end
     end
 
     describe "Updating a resource" do
       it "posts the update into the system" do
-        resource = Resource.build(data_document, mock_agent)
+        resource = Resource.new(data_document, mock_agent)
         resource.name = "Brotato"
         resource.save!
         expect(mock_agent).to have_received(:patch).with(resource)

--- a/spec/gladius/resource_spec.rb
+++ b/spec/gladius/resource_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 module Gladius

--- a/spec/gladius/resource_spec.rb
+++ b/spec/gladius/resource_spec.rb
@@ -12,29 +12,40 @@ module Gladius
         }
       }
     end
-    let(:mock_agent) { double(:agent, patch: nil) }
+    let(:mock_agent) { double(:agent, update: nil, create: nil) }
 
     describe "Basics" do
       it "supports initialization with a data document" do
-        resource = Resource.new(data_document, mock_agent)
+        resource = Resource.new(data_document, agent: mock_agent)
         expect(resource.type).to eq("potatoes")
         expect(resource.spots).to eq(4)
         expect(resource.name).to eq("Spudley")
       end
 
       it "can be converted back into a data document" do
-        resource = Resource.new(data_document, mock_agent)
+        resource = Resource.new(data_document, agent: mock_agent, new: false)
         jsonified = resource.to_jsonapi_hash
         expect(jsonified[:data]).to eq(data_document)
       end
     end
 
     describe "Updating a resource" do
-      it "posts the update into the system" do
-        resource = Resource.new(data_document, mock_agent)
+      it "patches the update into the system" do
+        resource = Resource.new(data_document, agent: mock_agent, new: false)
         resource.name = "Brotato"
         resource.save!
-        expect(mock_agent).to have_received(:patch).with(resource)
+        expect(mock_agent).to have_received(:update).with(resource)
+      end
+    end
+
+    describe "Creating a resource" do
+      it "posts the new model into the system" do
+        resource = Resource.new(agent: mock_agent)
+        resource.type = "potatoes"
+        resource.name = "Glados"
+        resource.spots = 2
+        resource.save!
+        expect(mock_agent).to have_received(:create).with(resource)
       end
     end
   end

--- a/spec/gladius/resource_spec.rb
+++ b/spec/gladius/resource_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+module Gladius
+  RSpec.describe(Resource) do
+    let(:data_document) do
+      {
+        data: {
+          type: "potatoes",
+          id: 12,
+          attributes: {
+            spots: 4,
+            name: "Spudley"
+          }
+        }
+      }
+    end
+    let(:mock_agent) { double(:agent, patch: nil) }
+
+    describe "Basics" do
+      it "supports initialization with a data document" do
+        resource = Resource.build(data_document, mock_agent)
+        expect(resource.type).to eq("potatoes")
+        expect(resource.spots).to eq(4)
+        expect(resource.name).to eq("Spudley")
+      end
+
+      it "can be converted back into a data document" do
+        resource = Resource.build(data_document, mock_agent)
+        jsonified = resource.to_jsonapi_hash
+        expect(jsonified).to eq(data_document)
+      end
+    end
+
+    describe "Updating a resource" do
+      it "posts the update into the system" do
+        resource = Resource.build(data_document, mock_agent)
+        resource.name = "Brotato"
+        resource.save!
+        expect(mock_agent).to have_received(:patch).with(resource)
+      end
+    end
+  end
+end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "test_app"
+
+RSpec.describe(Gladius) do
+  let(:conn) { Faraday.new { |c| c.adapter :rack, Rails.application } }
+
+  describe "Getting an Index of posts" do
+    it "Allows me to use a cool API to get the index of posts and enumerate them" do
+      3.times { Post.create! }
+      agent = Gladius::Agent.new("http://localhost/posts", connection: conn)
+      document_collection = agent.index
+
+      expect(document_collection[:data].length).to eq(3)
+    end
+  end
+
+  describe "Creating a new post, then viewing it" do
+    it "Allows me to create a new post and view it" do
+      agent = Gladius::Agent.new("http://localhost/posts", connection: conn)
+      expect do
+        post = agent.create!(title: "The title", body: "Body of post")
+        post_id = post.dig(:data, :id)
+        post = Post.find(post_id)
+        expect(post.title).to eq("The title")
+        expect(post.body).to eq("Body of post")
+      end.to change(Post, :count).by(1)
+    end
+  end
+end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe("Gladius Integration") do
       agent = Gladius::Agent.new("http://localhost/posts", connection: rack_faraday)
       document_collection = agent.index
 
-      expect(document_collection[:data].length).to eq(3)
+      expect(document_collection.length).to eq(3)
     end
   end
 
@@ -18,7 +18,7 @@ RSpec.describe("Gladius Integration") do
       agent = Gladius::Agent.new("http://localhost/posts", connection: rack_faraday)
       expect do
         post = agent.create!(title: "The title", body: "Body of post")
-        post_id = post.dig(:data, :id)
+        post_id = post.id
         post = Post.find(post_id)
         expect(post.title).to eq("The title")
         expect(post.body).to eq("Body of post")

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -17,11 +17,10 @@ RSpec.describe("Gladius Integration") do
     it "Allows me to create a new post and view it" do
       agent = Gladius::Agent.new("http://localhost/posts", connection: rack_faraday)
       expect do
-        post = agent.create!(title: "The title", body: "Body of post")
-        post_id = post.id
-        post = Post.find(post_id)
-        expect(post.title).to eq("The title")
-        expect(post.body).to eq("Body of post")
+        post = agent.new(title: "The title", body: "Body of post")
+        updated_post = post.save!
+        expect(updated_post.title).to eq("The title")
+        expect(updated_post.body).to eq("Body of post")
       end.to change(Post, :count).by(1)
     end
 

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -2,22 +2,20 @@
 require "spec_helper"
 require "test_app"
 
-RSpec.describe(Gladius) do
-  let(:conn) { Faraday.new { |c| c.adapter :rack, Rails.application } }
-
+RSpec.describe("Gladius Integration") do
   describe "Getting an Index of posts" do
     it "Allows me to use a cool API to get the index of posts and enumerate them" do
       3.times { Post.create! }
-      agent = Gladius::Agent.new("http://localhost/posts", connection: conn)
+      agent = Gladius::Agent.new("http://localhost/posts", connection: rack_faraday)
       document_collection = agent.index
 
       expect(document_collection[:data].length).to eq(3)
     end
   end
 
-  describe "Creating a new post, then viewing it" do
+  describe "Working with single posts" do
     it "Allows me to create a new post and view it" do
-      agent = Gladius::Agent.new("http://localhost/posts", connection: conn)
+      agent = Gladius::Agent.new("http://localhost/posts", connection: rack_faraday)
       expect do
         post = agent.create!(title: "The title", body: "Body of post")
         post_id = post.dig(:data, :id)
@@ -25,6 +23,25 @@ RSpec.describe(Gladius) do
         expect(post.title).to eq("The title")
         expect(post.body).to eq("Body of post")
       end.to change(Post, :count).by(1)
+    end
+
+    it "can fetch a post, and access its properties like methods" do
+      agent = Gladius::Agent.new("http://localhost/posts", connection: rack_faraday)
+      post = Post.create!(title: "Looks like a post", body: "Totally informative")
+      post_resource = agent.get(post.id)
+      expect(post_resource.id).to eq(post.id.to_s)
+      expect(post_resource.title).to eq("Looks like a post")
+      expect(post_resource.body).to eq("Totally informative")
+    end
+
+    it "can update a post" do
+      agent = Gladius::Agent.new("http://localhost/posts", connection: rack_faraday)
+      post = Post.create!(title: "Looks like a post", body: "Totally informative")
+      post_resource = agent.get(post.id)
+      post_resource.title = "Changed title"
+      post_resource.save!
+      post.reload
+      expect(post.title).to eq("Changed title")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,14 +85,6 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
-  config.around(:each) do |example|
-    DatabaseCleaner.cleaning do
-      example.run
-    end
-  end
+  require "rack_faraday_helper"
+  config.include RackFaradayHelper
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+$LOAD_PATH << File.join(File.dirname(__FILE__), "support")
+require "gladius"
+require "database_cleaner"
 
 # frozen_string_literal: true
 RSpec.configure do |config|
@@ -80,4 +84,15 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
 end

--- a/spec/support/config/database.yml
+++ b/spec/support/config/database.yml
@@ -1,0 +1,3 @@
+test:
+  adapter: sqlite3
+  database: test_db

--- a/spec/support/rack_faraday_helper.rb
+++ b/spec/support/rack_faraday_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RackFaradayHelper
   def rack_faraday
     Faraday.new { |c| c.adapter :rack, Rails.application }

--- a/spec/support/rack_faraday_helper.rb
+++ b/spec/support/rack_faraday_helper.rb
@@ -1,0 +1,5 @@
+module RackFaradayHelper
+  def rack_faraday
+    Faraday.new { |c| c.adapter :rack, Rails.application }
+  end
+end

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -65,5 +65,19 @@ end
 
 # routes
 Rails.application.routes.draw do
-  jsonapi_resources :posts, only: [:index, :create]
+  jsonapi_resources :posts
+end
+
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
 end

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# prepare active_record database
+require "active_record"
+
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+# Uncomment if you need to see the activerecord logger output for the schema loadout.
+# ActiveRecord::Base.logger = Logger.new(STDOUT)
+
+ActiveRecord::Schema.define do
+  # Add your schema here
+  create_table :posts, force: true do |t|
+    t.string :title
+    t.string :body
+  end
+end
+
+# create models
+class Post < ActiveRecord::Base
+end
+
+# prepare rails app
+require "action_controller/railtie"
+# require 'action_view/railtie'
+require "jsonapi-resources"
+
+class ApplicationController < ActionController::Base
+end
+
+# prepare jsonapi resources and controllers
+class PostsController < ApplicationController
+  include JSONAPI::ActsAsResourceController
+end
+
+# posts resource
+class PostResource < JSONAPI::Resource
+  attribute :title
+  attribute :body
+end
+
+# the core application
+class TestApp < Rails::Application
+  config.root = File.dirname(__FILE__)
+  # Config stdout logger with a really bare bones formatter.
+  config.logger = Logger.new(STDOUT,
+                             formatter: ->(s, _, _, msg) { "#{s[0]} -- #{msg}\n" })
+  ActiveRecord::Base.logger = config.logger
+  config.log_level = :info
+
+  ActiveRecord::Schema.verbose = false
+
+  secrets.secret_token = "secret_token"
+  secrets.secret_key_base = "secret_key_base"
+
+  config.eager_load = false
+end
+
+# initialize app
+Rails.application.initialize!
+
+JSONAPI.configure do |config|
+  config.json_key_format = :underscored_key
+  config.route_format = :underscored_key
+end
+
+# routes
+Rails.application.routes.draw do
+  jsonapi_resources :posts, only: [:index, :create]
+end

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -68,7 +68,6 @@ Rails.application.routes.draw do
   jsonapi_resources :posts
 end
 
-
 RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction


### PR DESCRIPTION
@bellycard/platform This is the initial functional prototype of Gladius, the tool for cutting through JSONAPI.

**Why does this exist?** Because [All existing clients](http://jsonapi.org/implementations/#client-libraries-ruby) follow an ORM-like pattern of defining a Class, which inherits from some base class, which implements the functionality. I dont' want to have to define classes and initializers, I just want to talk to a REST API, is that so hard?!

Things it doesn't yet support:
* Caching Resource structures
* Pagination
* Links/hypermedia
* Relationships

Things it does support:
* Index
* Get
* Create
* Update

I guess I didn't implement delete yet.

I'm looking for feedback, and a deputy to help maintain and move this forward. I hope this could be the basis of internal clients consuming our APIs, as well as being useful for our own tooling.

Cool Stuff:
* The Smallest Rails App Ever (just for testing, in-memory sqlite!)
* Faraday Rack adapter, which lets you make requests to rack applications, exercising more of the stack. Nice alternative *(compliment?)* to `Rack::Test`.
* Pretty printer.

Yes, I know:
* Not much test coverage, or consistency.
* Method missing (I tried not to, but this is better than subclassing Struct)
